### PR TITLE
Extra points use cases

### DIFF
--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -19,6 +19,6 @@ class StringCalculator
       raise "Negatives not allowed: #{negatives.join(', ')}"
     end
 
-    numbers.reduce(0, :+)
+    numbers.reject { |n| n > 1000 }.reduce(0, :+)
   end
 end

--- a/lib/string_calculator.rb
+++ b/lib/string_calculator.rb
@@ -8,8 +8,16 @@ class StringCalculator
 
     if input.start_with?("//")
       delimiter_line, input = input.split("\n", 2)
-      custom_delimiter = delimiter_line[2] # assumes single-character delimiter
-      delimiters = [custom_delimiter]
+      
+      # Handle multi-character delimiters inside square brackets
+      if delimiter_line.include?("[")
+        custom_delimiters = delimiter_line.scan(/\[([^\]]+)\]/).flatten
+        delimiters.concat(custom_delimiters)
+      else
+        # Single-character delimiter (e.g., //; or //, etc.)
+        custom_delimiter = delimiter_line[2]
+        delimiters = [custom_delimiter]
+      end
     end
 
     numbers = input.split(Regexp.union(delimiters)).map(&:to_i)

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -30,4 +30,8 @@ RSpec.describe StringCalculator do
   it "raises an exception for negative numbers" do
     expect { calc.add("1,-2,-3") }.to raise_error("Negatives not allowed: -2, -3")
   end
+
+  it "ignores numbers greater than 1000" do
+    expect(calc.add("2,1001")).to eq(2)
+  end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -38,4 +38,8 @@ RSpec.describe StringCalculator do
   it "supports custom delimiters of any length" do
     expect(calc.add("//[***]\n1***2***3")).to eq(6)
   end
+
+  it "supports multiple custom delimiters" do
+    expect(calc.add("//[*][%]\n1*2%3")).to eq(6)
+  end
 end

--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -34,4 +34,8 @@ RSpec.describe StringCalculator do
   it "ignores numbers greater than 1000" do
     expect(calc.add("2,1001")).to eq(2)
   end
+
+  it "supports custom delimiters of any length" do
+    expect(calc.add("//[***]\n1***2***3")).to eq(6)
+  end
 end


### PR DESCRIPTION
handle extra use case
Numbers bigger than 1000 should be ignored, so adding 2 + 1001 = 2
————————————————————————————————
Delimiters can be of any length with the following format: “//[delimiter]\n” for example: “//[***]\n1***2***3” should return 6